### PR TITLE
Bug fixed in training.py create_graph

### DIFF
--- a/netgan/training.py
+++ b/netgan/training.py
@@ -169,17 +169,18 @@ class Trainer():
         self.G_optimizer.step()
         return gen_cost.item()
 
-    def create_graph(self, num_samples, i, reset_weights=False):
+    def create_graph(self, num_samples, i, batch_size=1000, reset_weights=False):
         if reset_weights:
             self.generator.reset_weights()
         self.generator.eval()
 
         self.generator.temp = 0.5
         samples = []
-        num_iterations = int(num_samples/1000)+1
+        num_iterations = int(num_samples/batch_size)
+        print("Number iterations: " + str(num_iterations))
         for j in range(num_iterations):
             if(j%10 == 1): print(j)
-            samples.append(self.generator.sample_discrete(int(num_samples/1000), self.device))
+            samples.append(self.generator.sample_discrete(batch_size, self.device))
         samples = np.vstack(samples)
         gr = utils.score_matrix_from_random_walks(samples, self.N)
         gr = gr.tocsr()

--- a/netgan_modified/training.py
+++ b/netgan_modified/training.py
@@ -202,18 +202,18 @@ class Trainer():
         self.G_optimizer.step()
         return gen_cost.item()
 
-    def create_graph(self, num_samples, i, reset_weights=False):
+    def create_graph(self, num_samples, i, batch_size=1000, reset_weights=False):
         if reset_weights:
             self.generator.reset_weights()
         self.generator.eval()
 
         self.generator.temp = 0.5
         samples, samples_lines = [], []
-        num_iterations = int(num_samples/1000)+1
-        print('create graph:')
+        num_iterations = int(num_samples/batch_size)
+        print("Number iterations: " + str(num_iterations))
         for j in range(num_iterations):
             if(j%10 == 1): print('{}/{}'.format(j, num_iterations))
-            rw_smpls, lines_smpls = self.generator.sample_discrete(int(num_samples / 1000), self.device)
+            rw_smpls, lines_smpls = self.generator.sample_discrete(batch_size, self.device)
             samples.append(rw_smpls)
             samples_lines.append(lines_smpls)
         samples = np.vstack(samples)


### PR DESCRIPTION
Wrong number of samples were used in the function create_graph resulting in a low number of random walks generated. 